### PR TITLE
fix: Expose EventMap generic in TypeScript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,22 @@
 declare module 'ready-resource' {
-  import { EventEmitter } from 'events'
+  import { EventEmitter, EventMap } from 'events'
+
+  /**
+   * Default events that come with ReadyResource
+   * Adds type hints for `.on`/`once`/`.emit`
+   * Passed in EventMaps will get these added
+   */
+  interface ReadyResourceEvents {
+    ready: [],
+    close: []
+  }
 
   /**
    * Runtime export is CommonJS:
    *   module.exports = class ReadyResource extends EventEmitter {}
    * This declaration mirrors that shape.
    */
-  class ReadyResource extends EventEmitter {
+  class ReadyResource<T extends EventMap<T> = ReadyResourceEvents> extends EventEmitter<T & ReadyResourceEvents> {
     constructor() // eslint-disable-line constructor-super
 
     /** Set when a call to ready() has started; resolves when _open completes */
@@ -30,22 +40,6 @@ declare module 'ready-resource' {
     /** Override these in subclasses */
     protected _open(): Promise<void>
     protected _close(): Promise<void>
-
-    // Typed events emitted by the implementation
-    on(event: 'ready', listener: () => void): this
-    on(event: 'close', listener: () => void): this
-    once(event: 'ready', listener: () => void): this
-    once(event: 'close', listener: () => void): this
-    off(event: 'ready', listener: () => void): this
-    off(event: 'close', listener: () => void): this
-    emit(event: 'ready'): boolean
-    emit(event: 'close'): boolean
-
-    // Fallback EventEmitter overloads
-    on(event: string | symbol, listener: (...args: any[]) => void): this
-    once(event: string | symbol, listener: (...args: any[]) => void): this
-    off(event: string | symbol, listener: (...args: any[]) => void): this
-    emit(event: string | symbol, ...args: any[]): boolean
   }
 
   // Match CommonJS runtime export


### PR DESCRIPTION
Hey there, I noticed the current TypeScript declaration doesn't use the [EventMap](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ee54dfb7f243b0ede22b9456bf1a7addc6ff4f28/types/node/events.d.ts#L40) feature of EventEmitter.

Using this makes it easier to integrate with other parts of the TS ecosystem like [p-event](https://www.npmjs.com/package/p-event) and gives a straightforward way to declare event types without needing to add duplicate methods.

I've added a default EventMap to the declaration with the `ready` and `close` events, and added a generic to the class to be able to pass in more event types. Also got rid of the extra declarations for `on/once/emit` since they are no longer necessary.

Example of how consumer code can work:

```TypeScript
interface HypercoreEvents {
  'upload': [number, number, Peer]
}

class Hypercore extends ReadyResource<HypercoreEvents> {

}

// Type checked and editors will suggest the `update` event
core.on('upload', (index, byteLength, peer) => whatever())

// Still keeps base events from ReadyResource
core.once('close', () => cleanup())
```

Or using JSDoc type hints:

```JavaScript
/**
 * @typedef {{
 *  'upload': [number, number, Peer]
 * }} HypercoreEvents
 */

/** @type {ReadyResource<HypercoreEvents>} */
class Hypercore extends ReadyResource {

}

// Type checked and editors will suggest the `update` event
core.on('upload', (index, byteLength, peer) => whatever())

// Still keeps base events from ReadyResource
core.once('close', () => cleanup())
```
